### PR TITLE
Separator inheritance

### DIFF
--- a/addon/helpers/title.js
+++ b/addon/helpers/title.js
@@ -17,10 +17,6 @@ export default Ember.Helper.extend({
   },
 
   compute(params, hash) {
-    if (hash.separator == null) {
-      hash.separator = ' | ';
-    }
-
     let tokens = get(this, 'documentTitleList');
     hash.id = guidFor(this);
     hash.title = params.join('');

--- a/addon/services/document-title-list.js
+++ b/addon/services/document-title-list.js
@@ -11,7 +11,11 @@ export default Ember.Service.extend({
     set(this, 'length', 0);
   },
 
+  defaultSeparator: ' | ',
+
   push(token) {
+    let defaultSeparator = get(this, "defaultSeparator");
+
     let tokenForId = this.tokens.findBy('id', token.id);
     if (tokenForId) {
       let index = this.tokens.indexOf(tokenForId);
@@ -28,6 +32,11 @@ export default Ember.Service.extend({
           token.prepend = previous.prepend;
         }
       }
+
+      if (token.separator == null) {
+        token.separator = defaultSeparator;
+      }
+
       tokens.splice(index, 1, token);
       set(this, 'tokens', Ember.A(tokens));
       return;
@@ -45,6 +54,10 @@ export default Ember.Service.extend({
       if (token.prepend == null) {
         token.prepend = previous.prepend;
       }
+    }
+
+    if (token.separator == null) {
+      token.separator = defaultSeparator;
     }
 
     let tokens = copy(this.tokens);

--- a/tests/acceptance/posts-test.js
+++ b/tests/acceptance/posts-test.js
@@ -41,6 +41,15 @@ test('custom separators work', function(assert) {
   });
 });
 
+test('custom separators are inherited', function(assert) {
+  assert.expect(1);
+  visit('/about/authors/profile');
+
+  andThen(function() {
+    assert.equal(document.title, 'About My App > Authors > Profile');
+  });
+});
+
 test('multiple components in a row work', function(assert) {
   assert.expect(1);
   visit('/posts/rails-is-omakase');

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -7,7 +7,9 @@ var Router = Ember.Router.extend({
 
 Router.map(function() {
   this.resource('about', function () {
-    this.route('authors');
+    this.route('authors', function() {
+      this.route('profile');
+    });
   });
   this.resource('posts');
   this.resource('post', { path: '/posts/:post_id' });

--- a/tests/dummy/app/templates/about/authors.hbs
+++ b/tests/dummy/app/templates/about/authors.hbs
@@ -1,1 +1,3 @@
 {{title "Authors"}}
+
+{{outlet}}

--- a/tests/dummy/app/templates/about/authors/profile.hbs
+++ b/tests/dummy/app/templates/about/authors/profile.hbs
@@ -1,0 +1,1 @@
+{{title "Profile"}}


### PR DESCRIPTION
Closes #17 

This moves the default separator from being set in the helper which was causing it to break inheritance, to the service which knows about the previous separators etc…

When moving it into the service, I also moved the default it to a property so you can override it by extending the service (although just setting it in the application template is better & easier).